### PR TITLE
Fix false-positive blunder bar staying red after fast-forward move advance

### DIFF
--- a/app/components/BlunderWatch/BlunderButton.tsx
+++ b/app/components/BlunderWatch/BlunderButton.tsx
@@ -1,6 +1,6 @@
 // The primary input during playback — large fixed button on mobile, Space key on desktop.
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type FeedbackState = 'idle' | 'correct' | 'false_positive';
 
@@ -46,14 +46,25 @@ function TimerBar({ durationMs, moveKey }: { durationMs: number; moveKey: number
 
 export function BlunderButton({ onFlag, disabled, lastFlagResult, isPreGame = false, moveTimeMs, moveKey = 0, isWhiteMove = true, isFastForward = false }: BlunderButtonProps) {
   const [feedback, setFeedback] = useState<FeedbackState>('idle');
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Flash feedback when a flag result comes in
+  // Flash feedback when a flag result comes in.
+  // Use a ref for the timer so advancing to the next move (which resets lastFlagResult
+  // to null) doesn't cancel the in-progress flash via effect cleanup.
   useEffect(() => {
     if (!lastFlagResult) return;
+    if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
     setFeedback(lastFlagResult === 'correct' ? 'correct' : 'false_positive');
-    const timer = setTimeout(() => setFeedback('idle'), 600);
-    return () => clearTimeout(timer);
+    feedbackTimerRef.current = setTimeout(() => {
+      setFeedback('idle');
+      feedbackTimerRef.current = null;
+    }, 600);
   }, [lastFlagResult]);
+
+  // Clear timer on unmount
+  useEffect(() => () => {
+    if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
+  }, []);
 
   // During Black's move or fast-forward, show active style but no text/timer (cutscene)
   const isInactive = !isPreGame && (!isWhiteMove || isFastForward);


### PR DESCRIPTION
When a false positive was flagged during fast-forward (400ms pacing),
the next move advanced before the 600ms feedback timer fired. The effect
cleanup cancelled the timer when lastFlagResult reset to null, leaving
feedback stuck at 'false_positive'. Use a ref to manage the timer so
it runs to completion regardless of lastFlagResult transitions.

https://claude.ai/code/session_01HY6EHSRACmM8kpDFqZ4UNh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to a local timeout lifecycle; main risk is minor timing/regression in how long feedback is displayed.
> 
> **Overview**
> Ensures `BlunderButton`'s correct/false-positive flash always completes by moving the 600ms reset timeout to a `useRef`-managed timer instead of an effect-cleanup-managed local timer.
> 
> Adds explicit timeout cancellation on new results and a separate unmount cleanup to avoid stuck feedback during fast-forward move advancement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b966b626bed9b46750a8de40ff5f34c909534098. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->