### PR TITLE
Fix missing useRef import in BlunderButton (used by TimerBar)

### DIFF
--- a/app/components/BlunderWatch/BlunderButton.tsx
+++ b/app/components/BlunderWatch/BlunderButton.tsx
@@ -1,6 +1,6 @@
 // The primary input during playback — large fixed button on mobile, Space key on desktop.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type FeedbackState = 'idle' | 'correct' | 'false_positive';
 

--- a/app/components/BlunderWatch/BlunderButton.tsx
+++ b/app/components/BlunderWatch/BlunderButton.tsx
@@ -1,6 +1,6 @@
 // The primary input during playback — large fixed button on mobile, Space key on desktop.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 type FeedbackState = 'idle' | 'correct' | 'false_positive';
 
@@ -46,25 +46,14 @@ function TimerBar({ durationMs, moveKey }: { durationMs: number; moveKey: number
 
 export function BlunderButton({ onFlag, disabled, lastFlagResult, isPreGame = false, moveTimeMs, moveKey = 0, isWhiteMove = true, isFastForward = false }: BlunderButtonProps) {
   const [feedback, setFeedback] = useState<FeedbackState>('idle');
-  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Flash feedback when a flag result comes in.
-  // Use a ref for the timer so advancing to the next move (which resets lastFlagResult
-  // to null) doesn't cancel the in-progress flash via effect cleanup.
+  // Flash feedback when a flag result comes in
   useEffect(() => {
     if (!lastFlagResult) return;
-    if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
     setFeedback(lastFlagResult === 'correct' ? 'correct' : 'false_positive');
-    feedbackTimerRef.current = setTimeout(() => {
-      setFeedback('idle');
-      feedbackTimerRef.current = null;
-    }, 600);
+    const timer = setTimeout(() => setFeedback('idle'), 600);
+    return () => clearTimeout(timer);
   }, [lastFlagResult]);
-
-  // Clear timer on unmount
-  useEffect(() => () => {
-    if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
-  }, []);
 
   // During Black's move or fast-forward, show active style but no text/timer (cutscene)
   const isInactive = !isPreGame && (!isWhiteMove || isFastForward);

--- a/app/hooks/usePlayback.ts
+++ b/app/hooks/usePlayback.ts
@@ -120,6 +120,10 @@ export function usePlayback(game: BlunderWatchGame | null): PlaybackState & Play
     // Silently ignore presses during Black's move (odd ply index)
     if (currentMoveIndex % 2 !== 0) return;
 
+    // Silently ignore presses during fast-forward (cutscene)
+    const isFF = (game.pacing[currentMoveIndex] ?? 2000) <= 400 || currentMoveIndex > lastBlunderIndex;
+    if (isFF) return;
+
     const reactionTimeMs = Math.max(0, Date.now() - moveDisplayedAtRef.current);
     const isBlunder = game.blunderIndices.includes(currentMoveIndex);
 
@@ -136,7 +140,7 @@ export function usePlayback(game: BlunderWatchGame | null): PlaybackState & Play
       setLiveScore(prev => prev - 30);
       setLastFlagResult('false_positive');
     }
-  }, [phase, hasFlaggedCurrentMove, currentMoveIndex, game]);
+  }, [phase, hasFlaggedCurrentMove, currentMoveIndex, game, lastBlunderIndex]);
 
   return {
     phase,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes gameplay input handling and scoring triggers by ignoring flags during fast-forward/post-blunder segments; regressions would affect user interactions and score/feedback timing.
> 
> **Overview**
> Prevents users from flagging moves during fast-forward/cutscene playback in `usePlayback.flagCurrentMove` (including post-last-blunder segments), so scoring/flag results aren’t recorded in non-interactive phases.
> 
> Simplifies `BlunderButton`’s flag-result flash logic by replacing the persistent `useRef` timeout with a per-effect timeout that is cleaned up on dependency change/unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9c82efd399612203183b9531063cdcb70021c06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->