### PR TITLE
Add move history navigation, mobile touch UX, and per-move scoring

### DIFF
--- a/app/components/MultipleChoiceChess/GameOverModal.tsx
+++ b/app/components/MultipleChoiceChess/GameOverModal.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { accuracy } from "~/utils/multipleChoiceChess/scoring";
+import type { MoveHistoryEntry } from "~/routes/multipleChoiceChess.$gameId.$playerId";
 
 interface GameOverModalProps {
   result: 'white' | 'black' | 'draw';
@@ -12,6 +14,7 @@ interface GameOverModalProps {
   blackRank2: number;
   blackRank4: number;
   blackRank6: number;
+  moveHistory: MoveHistoryEntry[];
   onPlayAgain: () => void;
 }
 
@@ -22,6 +25,24 @@ const REASON_LABELS: Record<string, string> = {
   insufficient_material: 'Insufficient material',
   repetition: 'Threefold repetition',
 };
+
+const RANK_LABELS: Record<number, string> = {
+  1: 'Best',
+  2: '2nd',
+  4: '4th',
+  6: '6th',
+};
+
+const RANK_BADGE: Record<number, string> = {
+  1: 'bg-green-100 text-green-800 border-green-400',
+  2: 'bg-yellow-100 text-yellow-800 border-yellow-400',
+  4: 'bg-orange-100 text-orange-800 border-orange-400',
+  6: 'bg-red-100 text-red-800 border-red-400',
+};
+
+function lichessUrl(fen: string): string {
+  return `https://lichess.org/analysis?fen=${encodeURIComponent(fen)}`;
+}
 
 export default function GameOverModal({
   result,
@@ -35,8 +56,11 @@ export default function GameOverModal({
   blackRank2,
   blackRank4,
   blackRank6,
+  moveHistory,
   onPlayAgain,
 }: GameOverModalProps) {
+  const [showMoveList, setShowMoveList] = useState(false);
+
   const didWin = result === myColor;
   const isDraw = result === 'draw';
 
@@ -56,50 +80,148 @@ export default function GameOverModal({
 
   const headline = isDraw ? 'Draw' : didWin ? 'You win!' : 'You lose';
 
+  // Group moves into pairs for display
+  const movePairs: Array<{ white?: MoveHistoryEntry & { index: number }; black?: MoveHistoryEntry & { index: number } }> = [];
+  for (let i = 0; i < moveHistory.length; i++) {
+    const entry = { ...moveHistory[i], index: i };
+    if (entry.color === 'white') {
+      movePairs.push({ white: entry });
+    } else {
+      const lastPair = movePairs[movePairs.length - 1];
+      if (lastPair && !lastPair.black) {
+        lastPair.black = entry;
+      } else {
+        movePairs.push({ black: entry });
+      }
+    }
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
-      <div className="w-full max-w-md border-4 border-black bg-white font-neo">
-        <div className="border-b-4 border-black p-6 text-center">
+      <div className="w-full max-w-md border-4 border-black bg-white font-neo max-h-[90vh] flex flex-col">
+        <div className="border-b-4 border-black p-6 text-center shrink-0">
           <h2 className="text-3xl font-extrabold uppercase">{headline}</h2>
           <p className="mt-1 text-sm text-gray-600">{REASON_LABELS[reason] ?? reason}</p>
         </div>
 
-        <div className="grid grid-cols-2 divide-x-4 divide-black p-0">
-          <div className="p-5">
-            <div className="text-xs font-bold uppercase text-gray-500">You ({myColor})</div>
-            <div className="mt-2 space-y-1 text-sm text-gray-700">
-              <div>#1 picks: <span className="font-bold text-black">{myRanks.rank1}</span></div>
-              <div>#2 picks: <span className="font-bold text-black">{myRanks.rank2}</span></div>
-              <div>#4 picks: <span className="font-bold text-black">{myRanks.rank4}</span></div>
-              <div>#6 picks: <span className="font-bold text-black">{myRanks.rank6}</span></div>
+        {!showMoveList ? (
+          <>
+            <div className="grid grid-cols-2 divide-x-4 divide-black p-0">
+              <div className="p-5">
+                <div className="text-xs font-bold uppercase text-gray-500">You ({myColor})</div>
+                <div className="mt-2 space-y-1 text-sm text-gray-700">
+                  <div>#1 picks: <span className="font-bold text-black">{myRanks.rank1}</span></div>
+                  <div>#2 picks: <span className="font-bold text-black">{myRanks.rank2}</span></div>
+                  <div>#4 picks: <span className="font-bold text-black">{myRanks.rank4}</span></div>
+                  <div>#6 picks: <span className="font-bold text-black">{myRanks.rank6}</span></div>
+                </div>
+                <div className="mt-1 text-sm text-gray-600">{myAcc}% accuracy</div>
+                <div className="text-xs text-gray-400">{myMoves} moves</div>
+              </div>
+              <div className="p-5">
+                <div className="text-xs font-bold uppercase text-gray-500">
+                  Opponent ({myColor === 'white' ? 'black' : 'white'})
+                </div>
+                <div className="mt-2 space-y-1 text-sm text-gray-700">
+                  <div>#1 picks: <span className="font-bold text-black">{oppRanks.rank1}</span></div>
+                  <div>#2 picks: <span className="font-bold text-black">{oppRanks.rank2}</span></div>
+                  <div>#4 picks: <span className="font-bold text-black">{oppRanks.rank4}</span></div>
+                  <div>#6 picks: <span className="font-bold text-black">{oppRanks.rank6}</span></div>
+                </div>
+                <div className="mt-1 text-sm text-gray-600">{oppAcc}% accuracy</div>
+                <div className="text-xs text-gray-400">{oppMoves} moves</div>
+              </div>
             </div>
-            <div className="mt-1 text-sm text-gray-600">{myAcc}% accuracy</div>
-            <div className="text-xs text-gray-400">{myMoves} moves</div>
-          </div>
-          <div className="p-5">
-            <div className="text-xs font-bold uppercase text-gray-500">
-              Opponent ({myColor === 'white' ? 'black' : 'white'})
-            </div>
-            <div className="mt-2 space-y-1 text-sm text-gray-700">
-              <div>#1 picks: <span className="font-bold text-black">{oppRanks.rank1}</span></div>
-              <div>#2 picks: <span className="font-bold text-black">{oppRanks.rank2}</span></div>
-              <div>#4 picks: <span className="font-bold text-black">{oppRanks.rank4}</span></div>
-              <div>#6 picks: <span className="font-bold text-black">{oppRanks.rank6}</span></div>
-            </div>
-            <div className="mt-1 text-sm text-gray-600">{oppAcc}% accuracy</div>
-            <div className="text-xs text-gray-400">{oppMoves} moves</div>
-          </div>
-        </div>
 
-        <div className="border-t-4 border-black p-4">
+            {moveHistory.length > 0 && (
+              <div className="border-t-4 border-black px-4 py-3 shrink-0">
+                <button
+                  onClick={() => setShowMoveList(true)}
+                  className="w-full border-2 border-black px-4 py-2 font-bold uppercase text-sm hover:bg-black hover:text-white active:bg-black active:text-white"
+                >
+                  Review Moves →
+                </button>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="flex flex-col min-h-0 flex-1">
+            <div className="border-b-2 border-black px-4 py-2 flex items-center justify-between shrink-0">
+              <button
+                onClick={() => setShowMoveList(false)}
+                className="text-sm font-bold uppercase border-2 border-black px-2 py-0.5 hover:bg-black hover:text-white active:bg-black active:text-white"
+              >
+                ← Back
+              </button>
+              <span className="text-xs font-bold uppercase text-gray-500">Move Review</span>
+            </div>
+
+            <div className="overflow-y-auto flex-1">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 bg-white border-b-2 border-black">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs text-gray-400 font-normal w-8">#</th>
+                    <th className="px-2 py-2 text-left text-xs text-gray-400 font-normal">White</th>
+                    <th className="px-2 py-2 text-left text-xs text-gray-400 font-normal">Black</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {movePairs.map((pair, pairIdx) => (
+                    <tr key={pairIdx} className="border-b border-gray-100 last:border-0">
+                      <td className="px-3 py-2 text-xs text-gray-400">{pairIdx + 1}</td>
+                      <td className="px-2 py-2">
+                        {pair.white && (
+                          <MoveCell entry={pair.white} myColor={myColor} />
+                        )}
+                      </td>
+                      <td className="px-2 py-2">
+                        {pair.black && (
+                          <MoveCell entry={pair.black} myColor={myColor} />
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        <div className="border-t-4 border-black p-4 shrink-0">
           <button
             onClick={onPlayAgain}
-            className="w-full border-4 border-black bg-white px-6 py-3 font-extrabold uppercase tracking-wide hover:bg-black hover:text-white"
+            className="w-full border-4 border-black bg-white px-6 py-3 font-extrabold uppercase tracking-wide hover:bg-black hover:text-white active:bg-black active:text-white"
           >
             Play Again
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function MoveCell({ entry, myColor }: { entry: MoveHistoryEntry & { index: number }; myColor: 'white' | 'black' }) {
+  const isMe = entry.color === myColor;
+  const badgeClass = RANK_BADGE[entry.rank] ?? 'bg-gray-100 text-gray-600 border-gray-300';
+  const rankLabel = RANK_LABELS[entry.rank] ?? `#${entry.rank}`;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className={`font-bold ${isMe ? 'text-black' : 'text-gray-500'}`}>
+        {entry.san}
+      </span>
+      <span className={`text-xs border rounded px-1 py-0.5 shrink-0 ${badgeClass}`}>
+        {rankLabel}
+      </span>
+      <a
+        href={lichessUrl(entry.fenBefore)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs text-blue-600 hover:underline shrink-0"
+        title="Analyze on Lichess"
+      >
+        ♟
+      </a>
     </div>
   );
 }

--- a/app/components/MultipleChoiceChess/MoveChoices.tsx
+++ b/app/components/MultipleChoiceChess/MoveChoices.tsx
@@ -6,7 +6,7 @@ function renderSan(san: string) {
   return (
     <>
       {san.slice(0, idx)}
-      <span className="text-sm align-middle">x</span>
+      <span className="text-base align-middle">x</span>
       {san.slice(idx + 1)}
     </>
   );
@@ -40,17 +40,20 @@ export default function MoveChoices({
             onClick={() => !disabled && !hasPicked && onPick(move)}
             onMouseEnter={() => !hasPicked && onHover?.(move.uci)}
             onMouseLeave={() => !hasPicked && onHover?.(null)}
+            onTouchStart={() => !hasPicked && onHover?.(move.uci)}
+            onTouchEnd={() => !hasPicked && onHover?.(null)}
+            onTouchCancel={() => !hasPicked && onHover?.(null)}
             disabled={disabled || hasPicked}
             className={[
-              'border-4 border-black px-4 py-4 font-neo font-extrabold uppercase tracking-wide transition-colors',
+              'touch-manipulation border-4 border-black px-4 py-5 font-neo font-extrabold uppercase tracking-wide transition-colors',
               isPicked
                 ? 'bg-black text-white'
                 : hasPicked
                   ? 'bg-white text-gray-400 border-gray-300'
-                  : 'bg-white text-black hover:bg-black hover:text-white',
+                  : 'bg-white text-black hover:bg-black hover:text-white active:bg-black active:text-white',
             ].join(' ')}
           >
-            <span className="text-xl">{renderSan(move.san)}</span>
+            <span className="text-2xl leading-none">{renderSan(move.san)}</span>
           </button>
         );
       })}

--- a/app/components/MultipleChoiceChess/MoveHistory.tsx
+++ b/app/components/MultipleChoiceChess/MoveHistory.tsx
@@ -1,0 +1,134 @@
+import type { MoveHistoryEntry } from "~/routes/multipleChoiceChess.$gameId.$playerId";
+
+const RANK_LABELS: Record<number, string> = {
+  1: '#1',
+  2: '#2',
+  4: '#4',
+  6: '#6',
+};
+
+const RANK_COLORS: Record<number, string> = {
+  1: 'bg-green-100 text-green-800 border-green-400',
+  2: 'bg-yellow-100 text-yellow-800 border-yellow-400',
+  4: 'bg-orange-100 text-orange-800 border-orange-400',
+  6: 'bg-red-100 text-red-800 border-red-400',
+};
+
+interface MoveHistoryProps {
+  history: MoveHistoryEntry[];
+  viewingIndex: number | null; // null = current position
+  onSelectMove: (index: number | null) => void;
+  isGameActive: boolean;
+}
+
+export default function MoveHistory({
+  history,
+  viewingIndex,
+  onSelectMove,
+  isGameActive,
+}: MoveHistoryProps) {
+  if (history.length === 0) return null;
+
+  // Group into pairs: [white_move, black_move]
+  const pairs: Array<{ white?: MoveHistoryEntry & { index: number }; black?: MoveHistoryEntry & { index: number } }> = [];
+  for (let i = 0; i < history.length; i++) {
+    const entry = { ...history[i], index: i };
+    if (entry.color === 'white') {
+      pairs.push({ white: entry });
+    } else {
+      const lastPair = pairs[pairs.length - 1];
+      if (lastPair && !lastPair.black) {
+        lastPair.black = entry;
+      } else {
+        pairs.push({ black: entry });
+      }
+    }
+  }
+
+  return (
+    <div className="border-4 border-black bg-white font-neo">
+      <div className="border-b-2 border-black px-3 py-2 flex items-center justify-between">
+        <span className="text-xs font-bold uppercase tracking-wide">Move History</span>
+        {viewingIndex !== null && (
+          <button
+            onClick={() => onSelectMove(null)}
+            className="text-xs font-bold uppercase border-2 border-black px-2 py-0.5 hover:bg-black hover:text-white active:bg-black active:text-white"
+          >
+            ↓ Live
+          </button>
+        )}
+      </div>
+
+      <div className="max-h-48 overflow-y-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-200">
+              <th className="px-2 py-1 text-left text-xs text-gray-400 font-normal w-8">#</th>
+              <th className="px-2 py-1 text-left text-xs text-gray-400 font-normal w-1/2">White</th>
+              <th className="px-2 py-1 text-left text-xs text-gray-400 font-normal w-1/2">Black</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map((pair, pairIdx) => (
+              <tr key={pairIdx} className="border-b border-gray-100 last:border-0">
+                <td className="px-2 py-1 text-xs text-gray-400">{pairIdx + 1}</td>
+                <td className="px-1 py-1">
+                  {pair.white ? (
+                    <button
+                      onClick={() => onSelectMove(pair.white!.index)}
+                      className={[
+                        'flex items-center gap-1 rounded px-1 py-0.5 text-left w-full transition-colors',
+                        viewingIndex === pair.white.index
+                          ? 'bg-black text-white'
+                          : 'hover:bg-gray-100 active:bg-gray-200',
+                      ].join(' ')}
+                    >
+                      <span className="font-bold">{pair.white.san}</span>
+                      <span className={[
+                        'text-xs border rounded px-0.5 shrink-0',
+                        viewingIndex === pair.white.index
+                          ? 'bg-white text-black border-white'
+                          : RANK_COLORS[pair.white.rank] ?? 'bg-gray-100 text-gray-600 border-gray-300',
+                      ].join(' ')}>
+                        {RANK_LABELS[pair.white.rank] ?? `#${pair.white.rank}`}
+                      </span>
+                    </button>
+                  ) : null}
+                </td>
+                <td className="px-1 py-1">
+                  {pair.black ? (
+                    <button
+                      onClick={() => onSelectMove(pair.black!.index)}
+                      className={[
+                        'flex items-center gap-1 rounded px-1 py-0.5 text-left w-full transition-colors',
+                        viewingIndex === pair.black.index
+                          ? 'bg-black text-white'
+                          : 'hover:bg-gray-100 active:bg-gray-200',
+                      ].join(' ')}
+                    >
+                      <span className="font-bold">{pair.black.san}</span>
+                      <span className={[
+                        'text-xs border rounded px-0.5 shrink-0',
+                        viewingIndex === pair.black.index
+                          ? 'bg-white text-black border-white'
+                          : RANK_COLORS[pair.black.rank] ?? 'bg-gray-100 text-gray-600 border-gray-300',
+                      ].join(' ')}>
+                        {RANK_LABELS[pair.black.rank] ?? `#${pair.black.rank}`}
+                      </span>
+                    </button>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {!isGameActive && viewingIndex !== null && (
+        <div className="border-t-2 border-black px-3 py-1 text-xs text-gray-500 text-center">
+          Viewing move {viewingIndex + 1} of {history.length}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/routes/multipleChoiceChess.$gameId.$playerId.tsx
+++ b/app/routes/multipleChoiceChess.$gameId.$playerId.tsx
@@ -6,6 +6,7 @@ import Footer from "~/components/Footer";
 import Article from "~/components/Article";
 import EngineStatus from "~/components/MultipleChoiceChess/EngineStatus";
 import MoveChoices from "~/components/MultipleChoiceChess/MoveChoices";
+import MoveHistory from "~/components/MultipleChoiceChess/MoveHistory";
 import GameOverModal from "~/components/MultipleChoiceChess/GameOverModal";
 import { getEngine, getThinkTime } from "~/utils/multipleChoiceChess/stockfishEngine";
 import type { CandidateMove } from "~/utils/multipleChoiceChess/moveParser";
@@ -27,6 +28,15 @@ export const links: LinksFunction = () => [
 export const loader = async ({ params }: { params: { gameId?: string; playerId?: string } }) => {
   return Response.json({ gameId: params.gameId, playerId: params.playerId });
 };
+
+export interface MoveHistoryEntry {
+  color: 'white' | 'black';
+  san: string;
+  uci: string;
+  rank: number; // 1, 2, 4, 6
+  fenBefore: string; // FEN before this move (for lichess analysis)
+  fenAfter: string;  // FEN after this move
+}
 
 type Phase =
   | 'loading_engine'
@@ -80,6 +90,8 @@ export default function MultipleChoiceChessGame() {
   const [error, setError] = useState<string | null>(null);
   const [lastMove, setLastMove] = useState<[string, string] | undefined>(undefined);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [moveHistory, setMoveHistory] = useState<MoveHistoryEntry[]>([]);
+  const [viewingMoveIndex, setViewingMoveIndex] = useState<number | null>(null);
 
   const pollRef = useRef<NodeJS.Timeout | null>(null);
   const myColor = useRef<'white' | 'black' | null>(null);
@@ -201,6 +213,18 @@ export default function MultipleChoiceChessGame() {
       // engine-generated moves should always be legal; fall through to server
     }
 
+    // Track move in history
+    setMoveHistory(prev => [...prev, {
+      color: myColor.current ?? gs.turn,
+      san: move.san,
+      uci: move.uci,
+      rank: move.rank,
+      fenBefore: gs.fen,
+      fenAfter: optimisticFen,
+    }]);
+    // Return to live position when making a move
+    setViewingMoveIndex(null);
+
     try {
       const res = await fetch('/api/multipleChoiceChess/move', {
         method: 'POST',
@@ -216,9 +240,10 @@ export default function MultipleChoiceChessGame() {
 
       if (!res.ok) {
         const data = await res.json();
-        // Roll back optimistic update
+        // Roll back optimistic update and history entry
         setGameState(gs);
         setLastMove(undefined);
+        setMoveHistory(prev => prev.slice(0, -1));
         throw new Error(data.error ?? 'Move rejected');
       }
 
@@ -242,13 +267,41 @@ export default function MultipleChoiceChessGame() {
     }
   }, []);
 
-  const handleOpponentMove = useCallback((gs: GameState) => {
+  const handleOpponentMove = useCallback((gs: GameState, prevFen: string) => {
     stopPolling();
 
     if (gs.last_move) {
       const from = gs.last_move.slice(0, 2) as `${string}${string}`;
       const to = gs.last_move.slice(2, 4) as `${string}${string}`;
       setLastMove([from, to]);
+
+      // Compute SAN from prevFen + opponent UCI
+      try {
+        const chess = new Chess(prevFen);
+        const promotion = gs.last_move.length === 5 ? gs.last_move[4] : undefined;
+        const moveResult = chess.move({ from, to, promotion });
+        // The player who just moved: gs.turn is next player, so the mover is the opposite
+        const movedColor: 'white' | 'black' = gs.turn === 'white' ? 'black' : 'white';
+        setMoveHistory(prev => [...prev, {
+          color: movedColor,
+          san: moveResult.san,
+          uci: gs.last_move,
+          rank: gs.last_move_rank,
+          fenBefore: prevFen,
+          fenAfter: gs.fen,
+        }]);
+      } catch {
+        // If SAN computation fails, still show the move as UCI
+        const movedColor: 'white' | 'black' = gs.turn === 'white' ? 'black' : 'white';
+        setMoveHistory(prev => [...prev, {
+          color: movedColor,
+          san: gs.last_move,
+          uci: gs.last_move,
+          rank: gs.last_move_rank,
+          fenBefore: prevFen,
+          fenAfter: gs.fen,
+        }]);
+      }
     }
 
     setTimeout(() => {
@@ -281,6 +334,7 @@ export default function MultipleChoiceChessGame() {
       }
 
       if (gs.last_updated > lastUpdated && gs.status !== 'waiting') {
+        const prevFen = gameState?.fen ?? gs.fen;
         setGameState(gs);
         setLastUpdated(gs.last_updated);
         if (gs.status === 'complete') {
@@ -289,7 +343,7 @@ export default function MultipleChoiceChessGame() {
           return;
         }
         if (isMyTurn(gs)) {
-          handleOpponentMove(gs);
+          handleOpponentMove(gs, prevFen);
         }
       }
     }, POLL_INTERVAL);
@@ -358,7 +412,19 @@ export default function MultipleChoiceChessGame() {
 
   const color = gameState ? (getMyColor(gameState) ?? 'white') : 'white';
 
-  const hoverShapes = hoveredUci
+  // When viewing history, show that position; otherwise show live board
+  const displayedFen = viewingMoveIndex !== null
+    ? moveHistory[viewingMoveIndex]?.fenAfter ?? (gameState?.fen ?? 'start')
+    : (gameState?.fen ?? 'start');
+
+  const displayedLastMove: [string, string] | undefined = viewingMoveIndex !== null
+    ? [
+        moveHistory[viewingMoveIndex]?.uci.slice(0, 2) ?? '',
+        moveHistory[viewingMoveIndex]?.uci.slice(2, 4) ?? '',
+      ] as [string, string]
+    : lastMove;
+
+  const hoverShapes = hoveredUci && viewingMoveIndex === null
     ? [{ orig: hoveredUci.slice(0, 2) as Key, dest: hoveredUci.slice(2, 4) as Key, brush: 'blue' }]
     : [];
 
@@ -400,7 +466,7 @@ export default function MultipleChoiceChessGame() {
                 />
                 <button
                   onClick={copyLink}
-                  className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase hover:bg-black hover:text-white"
+                  className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase hover:bg-black hover:text-white active:bg-black active:text-white"
                 >
                   {linkCopied ? 'Copied!' : 'Copy'}
                 </button>
@@ -417,24 +483,53 @@ export default function MultipleChoiceChessGame() {
                 </div>
               }>
                 <Chessboard
-                  initialFen={gameState?.fen ?? 'start'}
+                  initialFen={displayedFen}
                   orientation={color}
                   viewOnly={true}
-                  lastMove={lastMove}
+                  lastMove={displayedLastMove}
                   highlightMoves={true}
                   movable={false}
                   autoShapes={hoverShapes}
                 />
               </Suspense>
 
-              {gameState?.status === 'active' && phase !== 'game_over' && (
+              {viewingMoveIndex !== null && (
+                <div className="mt-3 flex justify-between items-center">
+                  <div className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase text-gray-600">
+                    Move {viewingMoveIndex + 1} of {moveHistory.length}
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => setViewingMoveIndex(Math.max(0, viewingMoveIndex - 1))}
+                      disabled={viewingMoveIndex === 0}
+                      className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase disabled:opacity-40 hover:bg-black hover:text-white active:bg-black active:text-white"
+                    >
+                      ←
+                    </button>
+                    <button
+                      onClick={() => {
+                        if (viewingMoveIndex < moveHistory.length - 1) {
+                          setViewingMoveIndex(viewingMoveIndex + 1);
+                        } else {
+                          setViewingMoveIndex(null);
+                        }
+                      }}
+                      className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase hover:bg-black hover:text-white active:bg-black active:text-white"
+                    >
+                      {viewingMoveIndex < moveHistory.length - 1 ? '→' : '↓ Live'}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {gameState?.status === 'active' && phase !== 'game_over' && viewingMoveIndex === null && (
                 <div className="mt-3 flex justify-between items-center">
                   <div className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase text-gray-600">
                     {gameState.turn === color ? 'Your turn' : "Opponent's turn"}
                   </div>
                   <button
                     onClick={handleResign}
-                    className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase text-gray-600 hover:bg-red-100 hover:text-red-700 hover:border-red-500"
+                    className="border-2 border-black px-3 py-1 font-neo text-sm font-bold uppercase text-gray-600 hover:bg-red-100 hover:text-red-700 hover:border-red-500 active:bg-red-100 active:text-red-700"
                   >
                     Resign
                   </button>
@@ -449,7 +544,7 @@ export default function MultipleChoiceChessGame() {
                 <EngineStatus phase="opponent" />
               )}
 
-              {(phase === 'my_choosing' || phase === 'submitting') && candidates.length > 0 && (
+              {(phase === 'my_choosing' || phase === 'submitting') && candidates.length > 0 && viewingMoveIndex === null && (
                 <div>
                   <MoveChoices
                     moves={candidates}
@@ -460,6 +555,13 @@ export default function MultipleChoiceChessGame() {
                   />
                 </div>
               )}
+
+              <MoveHistory
+                history={moveHistory}
+                viewingIndex={viewingMoveIndex}
+                onSelectMove={setViewingMoveIndex}
+                isGameActive={gameState?.status === 'active'}
+              />
             </div>
           </div>
         </Article>
@@ -479,6 +581,7 @@ export default function MultipleChoiceChessGame() {
           blackRank2={gameState.black_rank_2}
           blackRank4={gameState.black_rank_4}
           blackRank6={gameState.black_rank_6}
+          moveHistory={moveHistory}
           onPlayAgain={() => navigate('/multiple-choice-chess')}
         />
       )}


### PR DESCRIPTION
- MoveHistory sidebar: shows all moves from both sides with rank badges
  (#1 best, #2, #4, #6 worst) in a chess notation table; clicking any
  move navigates the board to that position with prev/next controls
- Mobile MoveChoices: added onTouchStart/End/Cancel for board-arrow
  preview on touch, active: tap feedback classes, larger text (2xl),
  and touch-manipulation to eliminate 300ms tap delay
- GameOverModal per-move review: "Review Moves" tab shows every move
  with a colour-coded rank badge and a ♟ lichess analysis link anchored
  to the position before the move so players can explore alternatives

https://claude.ai/code/session_01X1fD6WQsCr9QTq85DTFxSd