### PR TITLE
fix: restore Lambda static file serving to fix broken CSS in production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,21 +95,14 @@ This is a personal website built with React Router 7, TypeScript, and deployed o
 
 ## Deployment Architecture Notes
 
-### Lambda zip: SSR build + handler + prod node_modules only
-The deployed Lambda (`server/`) is ~35 MB, of which ~34 MB is `node_modules` (`@aws-sdk` and `@smithy` alone are ~18 MB). It does NOT contain `build/client/` — images/fonts are not bundled. The static-file fallback in `server.ts` only fires under `arc sandbox` (it's gated on `ARC_ENV !== 'production'`).
-
-### Static assets are served from S3 directly
-`/images/*` (and `/fonts/*`) resolve to `VITE_CDN_URL` / `CDN_URL` — currently `https://remix-website-writing-posts.s3.us-west-2.amazonaws.com`. Two mechanisms keep paths off the Lambda:
-1. **Compiled MDX**: `scripts/compile-mdx.mjs` rewrites `src:"/images/..."` → `src:"${CDN_BASE}/images/..."` at build time (env loaded via `--env-file-if-exists=.env`).
-2. **App code**: use `app/utils/cdn.ts` (`getImageUrl`, `image`) — never hardcode `/images/...` in TSX.
-
-Anything that still ships a raw `/images/...` path to the browser will hit the Lambda and 404.
+### Lambda zip: SSR build + handler + client assets + prod node_modules
+The deployed Lambda (`server/`) contains `build/client/` because the CI/CD (`deploy.yml`) runs `cp -r build server/` which bundles all Vite client assets into the Lambda zip. The static-file fallback in `server.ts` serves `/assets/*`, `/fonts/*`, and `/images/*` directly from `build/client/` in production and from `../public/` in the sandbox.
 
 ### Lambda response size cap is 6 MB (effectively ~4.5 MB raw)
 API Gateway rejects Lambda responses larger than 6 MB. Because the handler base64-encodes binary assets (~1.33× expansion), the practical raw-file limit is ~4.5 MB. Symptom of going over: HTTP 500 with body `{"message":"Internal Server Error"}` and `apigw-requestid` header. The Stockfish WASM (7.3 MB) hit this — now offloaded to unpkg CDN; see `app/utils/multipleChoiceChess/stockfishEngine.ts`.
 
 ### When cutting Lambda size further: target node_modules
-With static assets already off-Lambda, the remaining bloat is server `node_modules`. Top offenders: `@aws-sdk` (10 MB) + `@smithy` (7.7 MB), then `react-dom` (4.4 MB) and `react-router` (4 MB). The esbuild step in `build:arc:server` already externalizes `@aws-sdk/*` from `index.mjs`, but they're still installed by `build:arc:deps` because the AWS preset/server code requires them at runtime. Pruning unused AWS SDK clients (only `client-s3` and `client-dynamodb` are used) would be the next big win.
+The remaining bloat is server `node_modules`. Top offenders: `@aws-sdk` (10 MB) + `@smithy` (7.7 MB), then `react-dom` (4.4 MB) and `react-router` (4 MB). The esbuild step in `build:arc:server` already externalizes `@aws-sdk/*` from `index.mjs`, but they're still installed by `build:arc:deps` because the AWS preset/server code requires them at runtime. Pruning unused AWS SDK clients (only `client-s3` and `client-dynamodb` are used) would be the next big win.
 
 ## Recent Changes
 - 001-modernize-website: Standardized Tailwind CSS patterns, decomposed large routes, unified typography system, enforced code standards via ESLint

--- a/server.ts
+++ b/server.ts
@@ -28,15 +28,13 @@ async function handlerFn(event: any, context: any) {
     // In local dev, serve static files from public directory
     const path = event.rawPath || event.path || event.requestContext?.http?.path;
     
-    // Serve static files for the local arc sandbox only.
-    // In production, /assets/*, /fonts/*, /images/* are served from S3/CloudFront
-    // (compiled MDX has CDN-absolute URLs baked in via scripts/compile-mdx.mjs;
-    // app code uses app/utils/cdn.ts). Lambda zip does not contain build/client.
-    if (
-      process.env.ARC_ENV !== 'production' &&
-      (path?.startsWith('/assets/') || path?.startsWith('/fonts/') || path?.startsWith('/images/'))
-    ) {
-      const publicDir = join(process.cwd(), '..', 'public');
+    // Serve static files in all environments when using spa mode
+    // In production, files are in build/client/, in dev they're in ../public/
+    if (path?.startsWith('/assets/') || path?.startsWith('/fonts/') || path?.startsWith('/images/')) {
+      const isProduction = process.env.ARC_ENV === 'production';
+      const publicDir = isProduction
+        ? join(process.cwd(), 'build', 'client')
+        : join(process.cwd(), '..', 'public');
       const filePath = join(publicDir, path);
       
       if (existsSync(filePath)) {


### PR DESCRIPTION
The previous PR added a production gate (ARC_ENV !== 'production') to the
static file handler in server.ts, but the CI/CD deploy.yml copies the
entire build/ directory into the Lambda zip via `cp -r build server/`.
This means build/client/ IS present in the Lambda, and the static file
handler was the mechanism actually serving CSS/fonts/images in production.
Removing the production gate caused all CSS to break.

Restores the original logic: serve /assets/, /fonts/, /images/ from
build/client/ in production and ../public/ in the sandbox.
Also corrects the CLAUDE.md deployment architecture note which incorrectly
stated the Lambda did not contain build/client.

https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx