### PR TITLE
fix: restore CSS in prod, then shrink Lambda the right way

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,9 +123,17 @@ jobs:
         run: |
           NODE_ENV=production npx esbuild server.ts --platform=node --target=node22 --format=esm --bundle --minify --outfile=server/index.mjs '--external:@aws-sdk/*' --external:aws-sdk '--external:@react-router/*' --external:react --external:react-dom '--external:./build/*'
           
-      - name: 📦 Copy build output to Lambda
+      - name: 📦 Copy build output to Lambda (excluding images, served from S3/CDN)
         run: |
-          cp -r build server/
+          mkdir -p server/build/client server/build/server
+          cp -r build/server/. server/build/server/
+          cp -r build/client/assets server/build/client/
+          [ -d build/client/fonts ] && cp -r build/client/fonts server/build/client/ || true
+          find build/client -maxdepth 1 -type f -exec cp {} server/build/client/ \;
+          echo "Lambda build/client contents:"
+          du -sh server/build/client/* 2>/dev/null || true
+          echo "Total Lambda build/ size:"
+          du -sh server/build
           
       - name: 🔍 Verify public directory
         run: |

--- a/app/components/LazyLightbox.tsx
+++ b/app/components/LazyLightbox.tsx
@@ -1,0 +1,16 @@
+import { lazy, Suspense, type ComponentProps } from "react";
+import "yet-another-react-lightbox/styles.css";
+import type LightboxImport from "yet-another-react-lightbox";
+
+const Lightbox = lazy(() => import("yet-another-react-lightbox"));
+
+type LightboxProps = ComponentProps<typeof LightboxImport>;
+
+export default function LazyLightbox(props: LightboxProps) {
+  if (!props.open) return null;
+  return (
+    <Suspense fallback={null}>
+      <Lightbox {...props} />
+    </Suspense>
+  );
+}

--- a/app/routes/SSBM.tsx
+++ b/app/routes/SSBM.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import LightboxComponent from "yet-another-react-lightbox";
-import "yet-another-react-lightbox/styles.css";
+import LightboxComponent from "../components/LazyLightbox";
 
 const boxxRender = getImageUrl('SSBM/boxxRender.jpg');
 const barronBoxx = getImageUrl('SSBM/barronBoxx.jpg');

--- a/app/routes/camelUpCup.tsx
+++ b/app/routes/camelUpCup.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import LightboxComponent from "yet-another-react-lightbox";
-import "yet-another-react-lightbox/styles.css";
+import LightboxComponent from "../components/LazyLightbox";
 
 const eventTwo = getImageUrl('CamelUpCup/eventTwo.jpg');
 const eventOne = getImageUrl('CamelUpCup/eventOne.jpg');

--- a/app/routes/generativeArt.tsx
+++ b/app/routes/generativeArt.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import LightboxComponent from "yet-another-react-lightbox";
-import "yet-another-react-lightbox/styles.css";
+import LightboxComponent from "../components/LazyLightbox";
 
 const pic5 = getImageUrl('GenerativeArt/5.jpg');
 const pic4 = getImageUrl('GenerativeArt/4.jpg');

--- a/app/routes/set.tsx
+++ b/app/routes/set.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import LightboxComponent from "yet-another-react-lightbox";
-import "yet-another-react-lightbox/styles.css";
+import LightboxComponent from "../components/LazyLightbox";
 
 const setSetup = getImageUrl('Set/setSetup.jpg');
 const setAnswers = getImageUrl('Set/setAnswers.jpg');

--- a/app/routes/theRiddler.tsx
+++ b/app/routes/theRiddler.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import LightboxComponent from "yet-another-react-lightbox";
-import "yet-another-react-lightbox/styles.css";
+import LightboxComponent from "../components/LazyLightbox";
 
 const crosswordTwo = getImageUrl('Riddler/crosswordTwo.png');
 const crosswordOne = getImageUrl('Riddler/crosswordOne.png');


### PR DESCRIPTION
## Summary

PR #17 broke CSS in production by gating the Lambda's static-file handler to non-prod, on the assumption that the Lambda zip didn't contain `build/client/`. It actually does — `.github/workflows/deploy.yml` runs `cp -r build server/` which bundles every Vite client asset into the Lambda. The static handler at `process.cwd()/build/client/` was the actual mechanism serving `/assets/*.css` in production. Once it was gated out, every CSS request fell through to React Router and 404'd.

This PR fixes that and follows up with two targeted size reductions.

### Commit 1 — restore Lambda static file serving (CSS fix)

- Revert `server.ts` to serve `/assets/*`, `/fonts/*`, and `/images/*` from `build/client/` in production and `../public/` in the sandbox.
- Correct the `CLAUDE.md` deployment-architecture note that incorrectly claimed the Lambda did not contain `build/client/`.

### Commit 2 — shrink Lambda (~3.7 MB + lightbox source)

- **Skip images in the Lambda zip.** Replace the blanket `cp -r build server/` with a selective copy that includes `build/server/`, `build/client/assets/`, `build/client/fonts/`, and top-level files (favicon, etc.) but omits `build/client/images/`. Images are already served from S3 via `app/utils/cdn.ts` and `compile-mdx.mjs` rewrites `/images/` refs in MDX to absolute CDN URLs. Adds `du -sh server/build` logging so the actual diff is visible in CI.
- **Lazy-load `yet-another-react-lightbox`.** New `app/components/LazyLightbox.tsx` wraps the lib in `React.lazy` + `Suspense` and short-circuits on `props.open === false`, so the source isn't evaluated during SSR. The 5 routes that imported it directly (`SSBM`, `theRiddler`, `camelUpCup`, `generativeArt`, `set`) now import the wrapper. CSS import moved into the wrapper.

## Test plan

- [ ] `npm run typecheck` passes locally (verified — only an unrelated pre-existing TS6 deprecation warning).
- [ ] CI deploy step prints the new `du -sh server/build` size — confirm it dropped vs. the previous build.
- [ ] After deploy: hard-reload the site and verify CSS loads (no `/assets/*.css` 404s in network tab).
- [ ] Open a route with the lightbox (e.g. `/SSBM`, `/theRiddler`) and click an image — lightbox should mount, transition, and navigate normally.
- [ ] Spot-check a blog post with images (e.g. `/posts/movingSofaProblem`) — images should load from the CDN URL, not `/images/`.

https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx

---
_Generated by [Claude Code](https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx)_