### PR TITLE
fix: align server/package.json React version to ^19.0.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,8 +8,8 @@
     "ioredis": "^5.8.2",
     "isbot": "^4.1.0",
     "mnemonist": "^0.39.8",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-router": "^7.0.1",
     "topojson-client": "^3.1.0",
     "yet-another-react-lightbox": "^3.21.5"


### PR DESCRIPTION
## Summary

- `server/package.json` was pinned to `react@^18.2.0` and `react-dom@^18.2.0`, but the root package uses `^19.0.0` and all SSR bundles are compiled against React 19.
- Since esbuild externalizes `react`/`react-dom` from the Lambda bundle, the runtime versions come from `server/node_modules` — meaning the Lambda was running React 18 against a React 19 compiled build.
- This aligns both to `^19.0.0`.

## Test plan

- [ ] CI passes (TypeScript + ESLint).
- [ ] After deploy: spot-check a React-heavy page (e.g. Multiple Choice Chess) and confirm no runtime errors in the Lambda logs.

https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx

---
_Generated by [Claude Code](https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx)_