### PR TITLE
perf: serve client assets from S3 CDN, eliminate build/client from Lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,16 +123,30 @@ jobs:
         run: |
           NODE_ENV=production npx esbuild server.ts --platform=node --target=node22 --format=esm --bundle --minify --outfile=server/index.mjs '--external:@aws-sdk/*' --external:aws-sdk '--external:@react-router/*' --external:react --external:react-dom '--external:./build/*'
           
-      - name: 📦 Copy build output to Lambda (excluding images, served from S3/CDN)
+      - name: 📤 Upload JS/CSS/font assets to CDN and configure S3 CORS
+        if: github.ref == 'refs/heads/master'
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
-          mkdir -p server/build/client server/build/server
-          cp -r build/server/. server/build/server/
-          cp -r build/client/assets server/build/client/
-          [ -d build/client/fonts ] && cp -r build/client/fonts server/build/client/ || true
-          find build/client -maxdepth 1 -type f -exec cp {} server/build/client/ \;
-          echo "Lambda build/client contents:"
-          du -sh server/build/client/* 2>/dev/null || true
-          echo "Total Lambda build/ size:"
+          # Enable CORS so <script type=module> can load JS chunks cross-origin
+          aws s3api put-bucket-cors --bucket "$AWS_BUCKET_NAME" --cors-configuration \
+            '{"CORSRules":[{"AllowedOrigins":["*"],"AllowedMethods":["GET","HEAD"],"AllowedHeaders":[],"MaxAgeSeconds":86400}]}'
+          # Content-hashed assets are immutable; sync with --delete to prune stale builds
+          aws s3 sync build/client/assets/ "s3://$AWS_BUCKET_NAME/assets/" \
+            --delete \
+            --cache-control "public,max-age=31536000,immutable"
+          # Fonts have fixed names so skip --delete and use a shorter TTL
+          [ -d build/client/fonts ] && aws s3 sync build/client/fonts/ "s3://$AWS_BUCKET_NAME/fonts/" \
+            --cache-control "public,max-age=86400" || true
+
+      - name: 📦 Copy SSR build to Lambda (no client assets — they are on CDN)
+        run: |
+          mkdir -p server/build
+          cp -r build/server server/build/
+          echo "Lambda build/ size:"
           du -sh server/build
           
       - name: 🔍 Verify public directory

--- a/server.ts
+++ b/server.ts
@@ -28,13 +28,14 @@ async function handlerFn(event: any, context: any) {
     // In local dev, serve static files from public directory
     const path = event.rawPath || event.path || event.requestContext?.http?.path;
     
-    // Serve static files in all environments when using spa mode
-    // In production, files are in build/client/, in dev they're in ../public/
-    if (path?.startsWith('/assets/') || path?.startsWith('/fonts/') || path?.startsWith('/images/')) {
-      const isProduction = process.env.ARC_ENV === 'production';
-      const publicDir = isProduction
-        ? join(process.cwd(), 'build', 'client')
-        : join(process.cwd(), '..', 'public');
+    // Serve static files in the local arc sandbox only.
+    // In production all assets are served from the CDN (VITE_CDN_URL baked into
+    // the Vite build at compile time), so the Lambda never sees /assets/ requests.
+    if (
+      process.env.ARC_ENV !== 'production' &&
+      (path?.startsWith('/assets/') || path?.startsWith('/fonts/') || path?.startsWith('/images/'))
+    ) {
+      const publicDir = join(process.cwd(), '..', 'public');
       const filePath = join(publicDir, path);
       
       if (existsSync(filePath)) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,11 @@ function getGitVersion() {
   }
 }
 
+// Strip trailing slash then add one so base is always "https://cdn.example.com/"
+const cdnUrl = process.env.VITE_CDN_URL?.replace(/\/?$/, '/');
+
 export default defineConfig({
+  base: cdnUrl ?? '/',
   plugins: [
     reactRouter(),
     tsconfigPaths(),


### PR DESCRIPTION
## What this does

Removes `build/client/` (CSS, JS, fonts) from the Lambda zip entirely by baking the CDN base URL into the Vite build and uploading assets directly to S3.

### How it works

**Vite `base` option (`vite.config.ts`)**
When `VITE_CDN_URL` is set at build time (it is in CI), Vite emits CDN-absolute URLs for every asset reference in the SSR manifest and in `<link>`/`<script>` tags:
```
<link rel="stylesheet" href="https://remix-website-writing-posts.s3.us-west-2.amazonaws.com/assets/root-xxx.css">
<script src="https://…/assets/entry.client-xxx.js" type="module">
```
Falls back to `'/'` in local dev and `dev:arc` where `VITE_CDN_URL` is not set, so nothing changes locally.

**S3 asset upload (`deploy.yml`)**
New step after the Vite build:
- Sets S3 CORS policy on `AWS_BUCKET_NAME` so `<script type=module>` can load JS chunks cross-origin.
- Syncs `build/client/assets/` with `--delete` and `Cache-Control: immutable` (safe because Vite content-hashes all filenames).
- Syncs `build/client/fonts/` with a 24 h TTL (no `--delete`, fixed filenames).

**Lambda is SSR-only**
The "Copy build output to Lambda" step now only copies `build/server/`. The static file handler in `server.ts` is gated to `ARC_ENV !== 'production'` — production Lambda never sees `/assets/` or `/fonts/` requests.

### Expected size impact

Lambda went from ~14 MB to **SSR bundles + node_modules only** — no client assets at all.

## Test plan

- [ ] CI passes (TypeScript, ESLint).
- [ ] After deploy: hard-reload the site. Open DevTools Network tab → filter by CSS/JS → confirm assets load from the S3 CDN URL (not the API Gateway domain).
- [ ] Check no CORS errors in the browser console for JS module chunks.
- [ ] Spot-check a route with the lazy lightbox (e.g. `/SSBM`) — click an image to trigger the dynamic import from CDN.
- [ ] Check `du -sh server/build` in CI logs — should be much smaller than 14 MB.

## Risk

If `VITE_CDN_URL` is not set in the CI secrets, `base` falls back to `'/'` and the Lambda would need to serve assets again (which it can't, since they're no longer in the zip). The secret is already present and used for image CDN URLs, so this shouldn't be an issue — but worth double-checking the secret is set before merging.

https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx

---
_Generated by [Claude Code](https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx)_