### PR TITLE
perf: prune 4 unused deps from server/package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,14 +4,10 @@
     "@ballatech/react-router7-preset-aws": "^1.0.1",
     "chess.js": "^1.0.0",
     "chessground": "^9.1.1",
-    "d3-geo": "^3.1.1",
     "ioredis": "^5.8.2",
     "isbot": "^4.1.0",
-    "mnemonist": "^0.39.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router": "^7.0.1",
-    "topojson-client": "^3.1.0",
-    "yet-another-react-lightbox": "^3.21.5"
+    "react-router": "^7.0.1"
   }
 }


### PR DESCRIPTION
## What

Removes 4 packages from `server/package.json` that are installed into Lambda `node_modules` but never loaded during SSR:

| Package | Why removable |
|---|---|
| `d3-geo` | Only in `PizzaScoringMap.tsx`; that component is `lazy()`-loaded in `pizzaRating.tsx` — never in the SSR static import graph |
| `topojson-client` | Same as d3-geo |
| `mnemonist` | Zero imports found anywhere in the codebase |
| `yet-another-react-lightbox` | Live usage is only `LazyLightbox`'s dynamic `import()`; `PhotoGallery.tsx` has a static import but is dead code with no consumers |

**Kept:** `chessground` — `blunderWatch.tsx` statically imports `BlunderWatch/GameBoard`, which statically imports chessground. It is in the SSR module graph.

## Expected impact

Estimated **3–5 MB** reduction in Lambda `node_modules` size. Combine with PR #21 (build/client removed from Lambda) and the total should be well under 10 MB.

## Test plan

- [ ] CI passes.
- [ ] After deploy: spot-check the four affected routes work correctly:
  - `/pizzaRating` — map renders (d3-geo/topojson loaded client-side via lazy)
  - `/blunderWatch` — chess board renders (chessground still in node_modules)
  - Any route with lightbox (e.g. `/SSBM`) — lightbox opens on click
  - Confirm no SSR errors in Lambda logs

https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx

---
_Generated by [Claude Code](https://claude.ai/code/session_012HqYrNiCVdBohSDaHzhYfx)_