### PR TITLE
Fix mobile button touch highlight on homepage cards

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -210,10 +210,10 @@ export default function Index() {
           <div className="w-full px-8">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {allProjects.map(({ to, title, description }) => (
-                <div key={to} className="border-4 border-black bg-white/90 backdrop-blur-sm hover:bg-black group transition-all duration-100">
-                  <Link to={to} className="block p-6 no-underline hover:no-underline h-full">
-                    <div className="font-neo font-bold text-xl text-black group-hover:text-white tracking-wide">{title.toUpperCase()}</div>
-                    <div className="font-neo text-sm mt-2 opacity-75 text-black group-hover:text-white group-hover:opacity-100 font-medium">{description}</div>
+                <div key={to} className="border-4 border-black">
+                  <Link to={to} className="block p-6 no-underline h-full bg-white/90 backdrop-blur-sm hover:bg-black active:bg-black group transition-all duration-100">
+                    <div className="font-neo font-bold text-xl text-black group-hover:text-white group-active:text-white tracking-wide">{title.toUpperCase()}</div>
+                    <div className="font-neo text-sm mt-2 opacity-75 text-black group-hover:text-white group-active:text-white group-hover:opacity-100 group-active:opacity-100 font-medium">{description}</div>
                   </Link>
                 </div>
               ))}
@@ -223,15 +223,15 @@ export default function Index() {
           <h2 className="text-4xl lg:text-5xl font-neo font-extrabold mb-12 mt-24 border-b-8 border-black pb-2 tracking-tighter uppercase text-black bg-white px-4">WRITING</h2>
           <ul className="w-full space-y-6 px-8">
             {posts.filter((post: Post) => post.type !== 'project').map((post: Post) => (
-              <li key={post.slug} className="border-4 border-black bg-white/90 backdrop-blur-sm hover:bg-black group transition-all duration-100">
-                <Link to={`/blog/${post.slug}`} className="block p-6 no-underline hover:no-underline">
-                  <div className="font-neo font-bold text-xl text-black group-hover:text-white tracking-wide">{post.title.toUpperCase()}</div>
+              <li key={post.slug} className="border-4 border-black">
+                <Link to={`/blog/${post.slug}`} className="block p-6 no-underline bg-white/90 backdrop-blur-sm hover:bg-black active:bg-black group transition-all duration-100">
+                  <div className="font-neo font-bold text-xl text-black group-hover:text-white group-active:text-white tracking-wide">{post.title.toUpperCase()}</div>
                   {post.subtitle && (
-                    <div className="font-neo text-base mt-2 text-black group-hover:text-white opacity-80 group-hover:opacity-100 font-medium">
+                    <div className="font-neo text-base mt-2 text-black group-hover:text-white group-active:text-white opacity-80 group-hover:opacity-100 group-active:opacity-100 font-medium">
                       {post.subtitle}
                     </div>
                   )}
-                  <div className="font-neo text-sm mt-2 opacity-75 text-black group-hover:text-white group-hover:opacity-100 font-medium">
+                  <div className="font-neo text-sm mt-2 opacity-75 text-black group-hover:text-white group-active:text-white group-hover:opacity-100 group-active:opacity-100 font-medium">
                     {new Date(post.date).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: 'long',

--- a/app/styles/index.css
+++ b/app/styles/index.css
@@ -23,6 +23,10 @@
 
 
 @layer base {
+  a {
+    -webkit-tap-highlight-color: transparent;
+  }
+
   body {
     font-family: var(--font-neo);
     background-color: #ffffff;


### PR DESCRIPTION
Move group/hover/active states from wrapper div to the Link element so
:active fires correctly on touch. Add active:bg-black and group-active:
text states for proper press feedback. Suppress browser default tap
highlight via -webkit-tap-highlight-color: transparent.

https://claude.ai/code/session_012F7smZRG3pFDSA7FnjpvwS