### PR TITLE
fix: white background for giscus comments on mobile

### DIFF
--- a/app/routes/giscus-theme[.]css.ts
+++ b/app/routes/giscus-theme[.]css.ts
@@ -4,12 +4,9 @@
 // Forks Primer's light theme (https://github.com/giscus/giscus styles/themes/light.css),
 // overriding the structural color variables and squaring off borders/shadows.
 const THEME_CSS = `
-html, body {
-  background-color: #ffffff;
-  color: #171717;
-}
+:root {
+  color-scheme: light;
 
-main {
   /* syntax highlighting — Primer light defaults */
   --color-prettylights-syntax-comment: #6e7781;
   --color-prettylights-syntax-constant: #0550ae;
@@ -96,7 +93,14 @@ main {
   --color-scale-blue-1: #b6e3ff;
   --color-social-reaction-bg-hover: #f0f0f0;
   --color-social-reaction-bg-reacted-hover: #e5e5e5;
+}
 
+html, body {
+  background-color: #ffffff !important;
+  color: #171717 !important;
+}
+
+main {
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3150,6 +3150,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
       "integrity": "sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3499,6 +3500,7 @@
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/@react-router/node/-/node-7.17.0.tgz",
       "integrity": "sha512-RYR47qM9gJ8zV8Ntial5Rkgcst2YnwWXt0Ai34FezzkDK6AILpxpVatEzFEhNRwbSh6JO6iweY7XhfM4/K5dBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0"
@@ -4943,7 +4945,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4953,7 +4955,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7289,7 +7291,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -19521,7 +19523,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
## Summary

- Move all giscus theme CSS variables from `main` to `:root` so they cascade correctly to `body` (CSS custom properties only inherit downward, so vars on `main` were invisible to ancestor elements like `body`)
- Add `color-scheme: light` to `:root` to prevent iOS dark mode from overriding the iframe's colors
- Add `!important` to explicit `html, body { background-color: #ffffff }` as a belt-and-suspenders override against giscus's bundled CSS

## Test plan

- [ ] Deploy and visit a blog post on mobile (iOS Safari in dark mode is the failure case)
- [ ] Confirm the giscus comments section shows a white background instead of black
- [ ] Confirm the comment input, reactions, and "Sign in with GitHub" button still render correctly

https://claude.ai/code/session_01NsLi5wJdT8cJCXZW4H1DqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsLi5wJdT8cJCXZW4H1DqA)_