### PR TITLE
fix: force light surface for giscus comments (paint main, not just :root)

### DIFF
--- a/app/routes/giscus-theme[.]css.ts
+++ b/app/routes/giscus-theme[.]css.ts
@@ -4,9 +4,17 @@
 // Forks Primer's light theme (https://github.com/giscus/giscus styles/themes/light.css),
 // overriding the structural color variables and squaring off borders/shadows.
 const THEME_CSS = `
-:root {
+/* Force light rendering: iOS Safari paints a cross-origin iframe's backdrop
+   dark when color-scheme resolves to dark and the content is transparent. */
+:root, html, body, main {
   color-scheme: light;
+}
 
+/* giscus paints the page surface by reading --color-canvas-default on <main>
+   (see its light.css). Define the palette on BOTH :root and main so our values
+   win regardless of whether giscus sets a dark default directly on main (a
+   main-scoped declaration beats an inherited :root one for the main element). */
+:root, main {
   /* syntax highlighting — Primer light defaults */
   --color-prettylights-syntax-comment: #6e7781;
   --color-prettylights-syntax-constant: #0550ae;
@@ -95,7 +103,9 @@ const THEME_CSS = `
   --color-social-reaction-bg-reacted-hover: #e5e5e5;
 }
 
-html, body {
+/* Paint an opaque white surface directly, so the section is light even if
+   giscus' own background rule loses the cascade or the iframe backdrop is dark. */
+html, body, main {
   background-color: #ffffff !important;
   color: #171717 !important;
 }

--- a/scripts/giscus-theme-check.mjs
+++ b/scripts/giscus-theme-check.mjs
@@ -1,0 +1,79 @@
+// Local closed-loop check for the giscus theme's light-mode cascade.
+//
+// giscus.app is not reachable from CI/sandboxes, so instead of loading the real
+// widget this reconstructs the relevant slice of giscus' own DOM + CSS:
+//   - a <main> whose background is painted from var(--color-canvas-default)
+//   - a giscus-style DARK default for that var declared directly on <main>
+//   - a transparent html/body (giscus blends into the host page)
+// then layers OUR theme CSS on top and renders under emulated iOS dark mode.
+// It asserts the computed background of html/body/main is white — i.e. our
+// override actually wins the cascade and the iframe backdrop is forced light.
+//
+// This validates the cascade + color-scheme logic, which is the thing that was
+// wrong. It does NOT exercise the real giscus.app (egress-blocked here); verify
+// the deployed widget on-device after shipping.
+import fs from "node:fs";
+import { chromium } from "playwright-core";
+
+const CHROME = "/opt/pw-browsers/chromium-1194/chrome-linux/chrome";
+const THEME_FILE = new URL("../app/routes/giscus-theme[.]css.ts", import.meta.url);
+
+function readThemeCss() {
+  const src = fs.readFileSync(THEME_FILE, "utf8");
+  const m = src.match(/const THEME_CSS = `([\s\S]*?)`;/);
+  if (!m) throw new Error("Could not extract THEME_CSS from route file");
+  return m[1];
+}
+
+// Mimic giscus' base styling: page surface comes from --color-canvas-default on
+// <main>, with a DARK default declared on main (the worst case for our override).
+const GISCUS_BASE_CSS = `
+  html, body { margin: 0; background: transparent; }
+  main {
+    --color-canvas-default: #0d1117;   /* giscus dark default, on main */
+    --color-fg-default: #e6edf3;
+    background-color: var(--color-canvas-default);
+    color: var(--color-fg-default);
+    min-height: 100vh;
+    padding: 16px;
+  }
+  .gsc-comment-box { border: 1px solid var(--color-border-default, #30363d); padding: 12px; }
+`;
+
+const html = (themeCss) => `<!doctype html><html><head>
+<style>${GISCUS_BASE_CSS}</style>
+<style id="theme">${themeCss}</style>
+</head><body><main>
+  <div class="gsc-reactions">0 reactions</div>
+  <div class="gsc-comment-box">Sign in to comment</div>
+</main></body></html>`;
+
+const browser = await chromium.launch({ executablePath: CHROME });
+const context = await browser.newContext({
+  colorScheme: "dark",
+  viewport: { width: 390, height: 844 },
+});
+const page = await context.newPage();
+await page.setContent(html(readThemeCss()), { waitUntil: "load" });
+
+const probe = await page.evaluate(() => {
+  const pick = (sel) => {
+    const el = sel === ":root" ? document.documentElement : document.querySelector(sel);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    return { bg: cs.backgroundColor, color: cs.color, colorScheme: cs.colorScheme };
+  };
+  return { html: pick(":root"), body: pick("body"), main: pick("main") };
+});
+
+const WHITE = "rgb(255, 255, 255)";
+const ok = probe.main.bg === WHITE && probe.body.bg === WHITE;
+
+console.log("computed styles under emulated iOS dark mode:");
+console.log(JSON.stringify(probe, null, 2));
+await page.screenshot({ path: "/tmp/giscus-check.png" });
+console.log(`\nmain background = ${probe.main.bg}`);
+console.log(ok ? "PASS: surface is white" : "FAIL: surface is not white");
+
+await browser.close();
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
## Summary

Follow-up to #29, which did not fix the black giscus background on iOS dark mode. v5.10.2 on `master` shipped that change and the comments section was still black, so this corrects the actual root cause.

**Root cause:** giscus paints the comment surface by reading `--color-canvas-default` **directly on its `<main>` element** (that's why giscus' own `light.css` declares the palette on `main`, not `:root`), with a *dark* default. A `main`-scoped custom property beats an inherited `:root` one for the `main` element, so defining the palette only on `:root` (the previous fix) left `main` resolving to giscus' dark `#0d1117` — the black surface.

## Changes

- Define the color palette on **both** `:root` and `main` so our values win regardless of where giscus sets its default.
- Set `color-scheme: light` on the document elements so iOS Safari stops painting the cross-origin iframe backdrop dark.
- Paint an opaque white `background-color` on `html, body, main` with `!important` as a backstop.
- Add `scripts/giscus-theme-check.mjs`, a headless-chromium cascade check.

Covers desktop and mobile dark mode alike — the same iframe theme drives both.

## Test plan

- [x] `scripts/giscus-theme-check.mjs` reconstructs giscus' DOM (a `main` painted from a dark `--color-canvas-default`), applies the live theme file, and renders under **emulated iOS dark mode**. New theme → `main` background `rgb(255,255,255)` (**PASS**); previously-deployed version → `rgb(13,17,23)` (**FAILS**, confirming the test discriminates).
- [ ] On-device check on the deployed site (iOS Safari, dark mode): comments section renders on a white background.

**Note:** `giscus.app` and `tylerbarron.com` are egress-blocked in the CI/sandbox environment, so the automated check validates the cascade/color-scheme logic against a faithful reconstruction rather than the live widget. Verify on-device after deploy.

https://claude.ai/code/session_01NsLi5wJdT8cJCXZW4H1DqA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsLi5wJdT8cJCXZW4H1DqA)_