### PR TITLE
ci: fix scripts lint globals and gate deploy on unit tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -87,11 +87,12 @@ export default tseslint.config(
     },
   },
 
-  // Node scripts and config files: Node globals, console allowed.
+  // Node scripts and config files: Node globals, console allowed. Browser
+  // globals too, since Playwright scripts reference them inside page.evaluate().
   {
     files: ['scripts/**/*.{js,mjs,cjs}', '*.config.{js,ts,cjs,mjs}', 'eslint.config.js'],
     languageOptions: {
-      globals: { ...globals.node },
+      globals: { ...globals.node, ...globals.browser },
     },
     rules: {
       'no-console': 'off',


### PR DESCRIPTION
## Summary

Two CI changes:

### 1. Fix the lint failure currently blocking `master`'s deploy
PR #30 merged `scripts/giscus-theme-check.mjs`, but the eslint fix for it did not land on `master` — so `master`'s CI lint step is failing, which blocks the deploy (and means the giscus theme fix from #30 has not actually gone out yet).

The script references `document` and `getComputedStyle` inside Playwright `page.evaluate()` callbacks, which execute in the browser. The scripts block in `eslint.config.js` only declared Node globals, so those tripped `no-undef`. Fix: add `globals.browser` alongside `globals.node` in that block.

### 2. Gate the deploy on passing unit tests
Previously the deploy job depended only on `[lint, typecheck]` — **tests did not need to pass to deploy**, so a broken unit test could ship to production. This adds a `🧪 Vitest` job running `npm test` and makes `deploy` depend on `[lint, typecheck, test]`.

The visual Playwright tests are intentionally left out of the gate: their snapshots are darwin-specific and the browser download isn't available on CI runners. Only the 160-test vitest unit suite gates deploy.

## Test plan

- [x] `npm run lint` passes clean (exit 0).
- [x] `npm test` passes — 160 tests across 11 files.
- [x] `deploy.yml` parses; `deploy.needs == [lint, typecheck, test]`.

https://claude.ai/code/session_01NsLi5wJdT8cJCXZW4H1DqA